### PR TITLE
correcting meta header.

### DIFF
--- a/html/home.html
+++ b/html/home.html
@@ -6,19 +6,19 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="lmnl. | conversations in liminal space">
-    <meta name="twitter:image:src" content="https://user-images.githubusercontent.com/96031819/168491238-5141d096-1dcd-41fb-bcd5-29bab702e8bc.jpg" />
-    <meta name="twitter:title" content="donuts-are-good/LMNL: liminal space" />
-    <meta name="twitter:description" content="lmnl. | conversations in liminal space" />
+    <meta name="description" content="conversations in liminal space">
+    <meta name="twitter:image:src" content="https://user-images.githubusercontent.com/96031819/168922056-5d98c05a-929d-4326-8c11-7f71b4241297.png" />
+    <meta name="twitter:title" content="lmnl." />
+    <meta name="twitter:description" content="conversations in liminal space" />
     <meta name="hostname" content="lxmxnxl.com">
     <meta name="color-scheme" content="light" />
-    <meta property="og:image" content="https://user-images.githubusercontent.com/96031819/168491238-5141d096-1dcd-41fb-bcd5-29bab702e8bc.jpg" />
-    <meta property="og:image:alt" content="liminal space. Contribute to donuts-are-good/LMNL development by creating an account on GitHub." />
-    <meta property="og:site_name" content="GitHub" />
+    <meta property="og:image" content="https://user-images.githubusercontent.com/96031819/168922056-5d98c05a-929d-4326-8c11-7f71b4241297.png" />
+    <meta property="og:image:alt" content="lmnl. | conversations in liminal space" />
+    <meta property="og:site_name" content="lmnl." />
     <meta property="og:type" content="object" />
-    <meta property="og:title" content="donuts-are-good/LMNL: liminal space" />
-    <meta property="og:url" content="https://github.com/lxmxnxl/LMNL" />
-    <meta property="og:description" content="lmnl. | conversations in liminal space" />
+    <meta property="og:title" content="lmnl." />
+    <meta property="og:url" content="https://github.com/lxmxnxl/lmnl" />
+    <meta property="og:description" content="conversations in liminal space" />
 
     <style>
       @charset "UTF-8";


### PR DESCRIPTION
used the github meta header code from the project page initially, forgot to remove the github parts of it. this should do for now, though the description and title and wordmark stuff probably should be worked out better.